### PR TITLE
Blank activity fix on Android 5.0

### DIFF
--- a/src/com/makemyandroidapp/parsenotificationexample/ParseApplication.java
+++ b/src/com/makemyandroidapp/parsenotificationexample/ParseApplication.java
@@ -12,7 +12,8 @@ public class ParseApplication extends Application {
 		super.onCreate();
 		Parse.initialize(this, Keys.applicationId, Keys.clientKey);
 		PushService.setDefaultPushCallback(this, MainActivity.class);
-		ParseInstallation.getCurrentInstallation().saveInBackground();
+		//ParseInstallation.getCurrentInstallation().saveInBackground();
+		ParseInstallation.getCurrentInstallation().saveEventually();
 	}
 
 }


### PR DESCRIPTION
ParseInstallation.getCurrentInstallation().saveInBackground(); will cause problems like a blank activity on android 5.0, by replacing it with ParseInstallation.getCurrentInstallation().saveEventually(); the problem is fixed
